### PR TITLE
Update docker cross compile guide for librespot 0.6.0 upgrade

### DIFF
--- a/docs/src/installation/cross-compile-using-docker.md
+++ b/docs/src/installation/cross-compile-using-docker.md
@@ -20,7 +20,7 @@ We can also use `docker` to cross compile on every platform and OS that runs `do
     ```yaml
     services:
       build-container:
-        image: rust:1.81-bookworm
+        image: rust:1-bookworm
         platform: linux/arm64
         command: bash -c "
             apt-get update &&

--- a/docs/src/installation/cross-compile-using-docker.md
+++ b/docs/src/installation/cross-compile-using-docker.md
@@ -13,22 +13,26 @@ We can also use `docker` to cross compile on every platform and OS that runs `do
 
     If you are **not** using Docker-Desktop you might have to install [QEMU](https://docs.docker.com/build/building/multi-platform/#install-qemu-manually)
 
-2. Create a docker `compose-file.yml`
+2. Create a docker `docker-compose.yml`
 
     Here we are building a `arm64` binary, so we set `platform: linux/arm64`
 
     ```yaml
     services:
       build-container:
-        image: rust:1.79-bookworm
+        image: rust:1.81-bookworm
         platform: linux/arm64
         command: bash -c "
             apt-get update &&
             apt-get install -y \
               libasound2-dev \
               libssl-dev \
+              jq \
               pkg-config &&
-            curl -sSL https://api.github.com/repos/Spotifyd/spotifyd/tarball/v0.3.5 | tar xz -C /spotifyd --strip-components=1 &&
+            wget -O - https://api.github.com/repos/Spotifyd/spotifyd/tarball/$(\
+                curl -SsL https://api.github.com/repos/Spotifyd/spotifyd/releases/latest \
+                  | jq '.tag_name' -r) \
+              | tar xzv -C /spotifyd --strip-components=1 &&
             cargo build --release &&
             cp /spotifyd/target/release/spotifyd /build/"
         working_dir: /spotifyd


### PR DESCRIPTION
- Enhanced log output
- Use latest GH Release
- Corrected compose filename

Update docs in https://github.com/Spotifyd/spotifyd/pull/1317